### PR TITLE
feat: add justfile for common dev tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ ehthumbs.db
 
 # Log files
 *.log
+
+# Local ADB device config
+.adb-device

--- a/justfile
+++ b/justfile
@@ -1,0 +1,67 @@
+# CoffeeShotTimer build commands
+# Run `just --list` to see available recipes
+
+export JAVA_HOME := "/usr/lib/jvm/java-21-openjdk"
+
+# Default recipe - show available commands
+default:
+    @just --list
+
+# --- Build & Test ---
+
+# Run detekt static analysis
+detekt:
+    ./gradlew detekt
+
+# Run Android lint (devDebug)
+lint:
+    ./gradlew lintDevDebug
+
+# Run unit tests (devDebug)
+test:
+    ./gradlew testDevDebugUnitTest
+
+# Build debug APK (devDebug)
+build:
+    ./gradlew assembleDevDebug
+
+# Clean build artifacts
+clean:
+    ./gradlew clean
+
+# Run all checks (detekt + lint + tests)
+check: detekt lint test
+
+# --- Device ---
+
+# Install debug APK on connected device
+install:
+    ./gradlew installDevDebug
+
+# Pair with device (one-time, requires pairing code from phone)
+adb-pair ip port:
+    adb pair {{ip}}:{{port}}
+
+# Auto-discover and connect via mDNS
+adb-connect:
+    #!/usr/bin/env bash
+    echo "Scanning for devices..."
+    DEVICE=$(adb mdns services 2>/dev/null | grep "_adb-tls-connect" | head -1)
+    if [ -z "$DEVICE" ]; then
+        echo "No devices found. Is Wireless Debugging enabled?"
+        exit 1
+    fi
+    ADDR=$(echo "$DEVICE" | awk '{print $NF}')
+    echo "Found: $ADDR"
+    adb connect "$ADDR"
+    adb devices
+
+# Show connected devices
+adb-status:
+    @adb devices
+
+# Restart ADB server
+adb-restart:
+    adb kill-server
+    adb start-server
+    @adb devices


### PR DESCRIPTION
## Summary

Adds a `justfile` for running common development tasks, replacing manual gradle commands.

## Commands

**Build & Test:**
- `just detekt` - Run detekt static analysis
- `just lint` - Run Android lint (devDebug)
- `just test` - Run unit tests (devDebug)
- `just build` - Build debug APK (devDebug)
- `just check` - Run all checks (detekt + lint + tests)
- `just clean` - Clean build artifacts

**Device:**
- `just install` - Install debug APK on connected device
- `just adb-connect` - Auto-discover and connect via mDNS
- `just adb-pair <ip> <port>` - Pair with device (one-time)
- `just adb-status` - Show connected devices
- `just adb-restart` - Restart ADB server

## Notes

- Commands match CI workflow (devDebug flavor)
- ADB connection uses mDNS auto-discovery, so no manual IP/port tracking needed
- JAVA_HOME is set automatically